### PR TITLE
Fix survival groups

### DIFF
--- a/functions/kmplot.R
+++ b/functions/kmplot.R
@@ -1,9 +1,11 @@
-create_kmplot <- function(fit, df, confint, risktable, title) {
+create_kmplot <- function(fit, df, confint, risktable, title, group_colors) {
+  group_colors <- set_names(group_colors, NULL)
   survminer::ggsurvplot(
     fit,
     data = df,
     conf.int = confint,
     risk.table = risktable,
-    title = title
+    title = title,
+    palette = group_colors
   )
 }

--- a/functions/transform.R
+++ b/functions/transform.R
@@ -288,9 +288,9 @@ build_tumor_content_df <- function(df, group_column) {
 
 # ** Clinical outcomes module ----
 
-build_survival_df <- function(df, group_column, time_column, k) {
+build_survival_df <- function(df, group_column, group_options, time_column, k) {
     get_groups <- function(df, group_column, k) {
-        if (group_column %in% c("Subtype_Immune_Model_Based")) {
+        if (group_column %in% group_options) {
             # then we don't need to produce catagories.
             as.character(df[[group_column]])
         }

--- a/server.R
+++ b/server.R
@@ -42,7 +42,8 @@ shinyServer(function(input, output, session) {
       reactive(input$ss_choice),
       reactive(group_internal_choice()),
       reactive(group_options()),
-      reactive(subset_df()))
+      reactive(subset_df()),
+      reactive(plot_colors()))
   # Immunomodulators
   callModule(
       immunomodulator, 

--- a/server.R
+++ b/server.R
@@ -40,6 +40,8 @@ shinyServer(function(input, output, session) {
       survival, 
       "module4", 
       reactive(input$ss_choice),
+      reactive(group_internal_choice()),
+      reactive(group_options()),
       reactive(subset_df()))
   # Immunomodulators
   callModule(


### PR DESCRIPTION
Get survival plot (and corresponding input options) to correctly update when global selection of sample groups changes; also use the correct plot colors for each sample group.